### PR TITLE
Step4

### DIFF
--- a/src/main/java/codesquad/domain/Answer.java
+++ b/src/main/java/codesquad/domain/Answer.java
@@ -1,11 +1,14 @@
 package codesquad.domain;
 
+import javax.naming.AuthenticationException;
 import javax.persistence.Entity;
 import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.Size;
+
+import org.springframework.transaction.annotation.Transactional;
 
 import codesquad.CannotDeleteException;
 import support.domain.AbstractEntity;
@@ -73,7 +76,11 @@ public class Answer extends AbstractEntity implements UrlGeneratable {
         return deleted;
     }
     
-    public void delete() throws CannotDeleteException {
+    
+    public void delete(User loginUser) throws CannotDeleteException, AuthenticationException {
+    	if (!isOwner(loginUser)) {
+			throw new AuthenticationException("자신의 글만 삭제 가능");
+		}
     	if(this.deleted) {
     		throw new CannotDeleteException("이미 삭제된 댓글");
     	}

--- a/src/main/java/codesquad/domain/Answer.java
+++ b/src/main/java/codesquad/domain/Answer.java
@@ -8,7 +8,6 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.Size;
 
-import org.springframework.transaction.annotation.Transactional;
 
 import codesquad.CannotDeleteException;
 import support.domain.AbstractEntity;
@@ -77,7 +76,7 @@ public class Answer extends AbstractEntity implements UrlGeneratable {
     }
     
     
-    public void delete(User loginUser) throws CannotDeleteException, AuthenticationException {
+    public DeleteHistory delete(User loginUser) throws CannotDeleteException, AuthenticationException {
     	if (!isOwner(loginUser)) {
 			throw new AuthenticationException("자신의 글만 삭제 가능");
 		}
@@ -85,6 +84,7 @@ public class Answer extends AbstractEntity implements UrlGeneratable {
     		throw new CannotDeleteException("이미 삭제된 댓글");
     	}
     	this.deleted = true;
+    	return new DeleteHistory(ContentType.ANSWER, getId(),loginUser);
     }
 
     @Override

--- a/src/main/java/codesquad/domain/DeleteHistory.java
+++ b/src/main/java/codesquad/domain/DeleteHistory.java
@@ -43,10 +43,59 @@ public class DeleteHistory {
     	this.contentId = contentId;
     	this.deletedBy = deletedBy;
     }
+    
+    public DeleteHistory(Long id, ContentType contentType, Long contentId, User deletedBy) {
+    	this.id = id;
+    	this.contentType = contentType;
+    	this.contentId = contentId;
+    	this.deletedBy = deletedBy;
+    }
 
     @Override
     public String toString() {
         return "DeleteHistory [id=" + id + ", contentType=" + contentType + ", contentId=" + contentId + ", deletedBy="
                 + deletedBy + ", createDate=" + createDate + "]";
     }
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((contentId == null) ? 0 : contentId.hashCode());
+		result = prime * result + ((contentType == null) ? 0 : contentType.hashCode());
+		result = prime * result + ((deletedBy == null) ? 0 : deletedBy.hashCode());
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		DeleteHistory other = (DeleteHistory) obj;
+		if (contentId == null) {
+			if (other.contentId != null)
+				return false;
+		} else if (!contentId.equals(other.contentId))
+			return false;
+		if (contentType != other.contentType)
+			return false;
+		if (deletedBy == null) {
+			if (other.deletedBy != null)
+				return false;
+		} else if (!deletedBy.equals(other.deletedBy))
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		return true;
+	}
+
+
 }

--- a/src/main/java/codesquad/domain/DeleteHistory.java
+++ b/src/main/java/codesquad/domain/DeleteHistory.java
@@ -37,6 +37,12 @@ public class DeleteHistory {
         this.deletedBy = deletedBy;
         this.createDate = createDate;
     }
+    
+    public DeleteHistory(ContentType contentType, Long contentId, User deletedBy) {
+    	this.contentType = contentType;
+    	this.contentId = contentId;
+    	this.deletedBy = deletedBy;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/codesquad/service/QnaService.java
+++ b/src/main/java/codesquad/service/QnaService.java
@@ -15,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 import codesquad.CannotDeleteException;
 import codesquad.domain.Answer;
 import codesquad.domain.AnswerRepository;
+import codesquad.domain.ContentType;
+import codesquad.domain.DeleteHistory;
 import codesquad.domain.Question;
 import codesquad.domain.QuestionRepository;
 import codesquad.domain.User;
@@ -47,16 +49,13 @@ public class QnaService {
 	public Question update(User loginUser, long id, Question updatedQuestion) throws AuthenticationException {
 		Question question = questionRepository.findById(id).orElseThrow(NullPointerException::new);
 		question.update(updatedQuestion, loginUser);
-//		return questionRepository.save(question);
 		return question;
 	}
 
 	@Transactional
-	public void deleteQuestion(User loginUser, long id) throws CannotDeleteException {
-		Question question = questionRepository.findById(id).filter(q -> q.isOwner(loginUser))
-				.orElseThrow(() -> new CannotDeleteException("본인만 수정 가능"));
-		question.delete(); 
-//		questionRepository.delete(question);
+	public void deleteQuestion(User loginUser, long id) throws CannotDeleteException, AuthenticationException {
+		Question question = questionRepository.findById(id).orElseThrow(NullPointerException::new);
+		question.delete(loginUser); 
 	}
 
 	public Iterable<Question> findAll() {
@@ -73,10 +72,8 @@ public class QnaService {
 	}
 
 	@Transactional
-	public void deleteAnswer(User loginUser, long id) throws CannotDeleteException {
-		Answer answer = answerRepository.findById(id).filter(a -> a.isOwner(loginUser))
-				.orElseThrow(() -> new CannotDeleteException("본인만 삭제 가능"));
-		answer.delete();
-//		answerRepository.save(answer);
+	public void deleteAnswer(User loginUser, long id) throws CannotDeleteException, AuthenticationException{
+		Answer answer = answerRepository.findById(id).orElseThrow(NullPointerException::new);
+		answer.delete(loginUser);
 	}
 }

--- a/src/main/java/codesquad/service/QnaService.java
+++ b/src/main/java/codesquad/service/QnaService.java
@@ -15,8 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import codesquad.CannotDeleteException;
 import codesquad.domain.Answer;
 import codesquad.domain.AnswerRepository;
-import codesquad.domain.ContentType;
-import codesquad.domain.DeleteHistory;
 import codesquad.domain.Question;
 import codesquad.domain.QuestionRepository;
 import codesquad.domain.User;
@@ -55,7 +53,14 @@ public class QnaService {
 	@Transactional
 	public void deleteQuestion(User loginUser, long id) throws CannotDeleteException, AuthenticationException {
 		Question question = questionRepository.findById(id).orElseThrow(NullPointerException::new);
-		question.delete(loginUser); 
+		deleteHistoryService.saveAll(question.delete(loginUser));
+		/*
+		 * 이거들어가니까 먼가로직적오류가나긴합니다.
+		DeleteHistory deleteHistory = new DeleteHistory(ContentType.QUESTION, id, loginUser);
+		List<DeleteHistory> deleteHistories = null;
+		deleteHistoryService.saveAll(deleteHistories);
+		*/
+		
 	}
 
 	public Iterable<Question> findAll() {

--- a/src/main/java/codesquad/web/ApiAnswerController.java
+++ b/src/main/java/codesquad/web/ApiAnswerController.java
@@ -4,6 +4,7 @@ package codesquad.web;
 import java.net.URI;
 
 import javax.annotation.Resource;
+import javax.naming.AuthenticationException;
 import javax.validation.Valid;
 
 import org.springframework.http.HttpHeaders;
@@ -36,7 +37,7 @@ public class ApiAnswerController {
 	}
 	
 	@DeleteMapping("{id}")
-	public void delete(@LoginUser User loginUser, @PathVariable Long id) throws CannotDeleteException {
+	public void delete(@LoginUser User loginUser, @PathVariable Long id) throws CannotDeleteException, AuthenticationException {
 		qnaService.deleteAnswer(loginUser, id);
 	}
 }

--- a/src/main/java/codesquad/web/ApiQuestionController.java
+++ b/src/main/java/codesquad/web/ApiQuestionController.java
@@ -52,7 +52,7 @@ public class ApiQuestionController {
 	}	
 	
 	@DeleteMapping("{id}")
-	public void delete(@LoginUser User loginUser, @PathVariable Long id) throws CannotDeleteException {
+	public void delete(@LoginUser User loginUser, @PathVariable Long id) throws CannotDeleteException, AuthenticationException {
 		qnaService.deleteQuestion(loginUser, id);
 	}
 }

--- a/src/main/java/codesquad/web/QuestionController.java
+++ b/src/main/java/codesquad/web/QuestionController.java
@@ -76,7 +76,7 @@ public class QuestionController {
 	}
 	
 	@DeleteMapping("/{id}")
-	public String delete(@LoginUser User loginUser, @PathVariable Long id) {
+	public String delete(@LoginUser User loginUser, @PathVariable Long id) throws AuthenticationException {
 		try {
 			qnaService.deleteQuestion(loginUser, id);
 		} catch (CannotDeleteException e) {

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -6,8 +6,8 @@ INSERT INTO question (id, writer_id, title, contents, create_date, deleted) VALU
 INSERT INTO question (id, writer_id, title, contents, create_date, deleted) VALUES (2, 2, 'runtime 에 reflect 발동 주체 객체가 뭔지 알 방법이 있을까요?', '설계를 희한하게 하는 바람에 꼬인 문제같긴 합니다만. 여쭙습니다. 상황은 mybatis select 실행될 시에 return object 의 getter 가 호출되면서인데요. getter 안에 다른 property 에 의존중인 코드가 삽입되어 있어서, 만약 다른 mybatis select 구문에 해당 property 가 없다면 exception 이 발생하게 됩니다.', CURRENT_TIMESTAMP(), false);
 
 INSERT INTO answer (writer_id, contents, create_date, question_id, deleted) VALUES (1, 'http://underscorejs.org/docs/underscore.html Underscore.js 강추합니다! 쓸일도 많고, 코드도 길지 않고, 자바스크립트의 언어나 기본 API를 보완하는 기능들이라 자바스크립트 이해에 도움이 됩니다. 무엇보다 라이브러리 자체가 아주 유용합니다.', CURRENT_TIMESTAMP(), 1, false);
-INSERT INTO answer (writer_id, contents, create_date, question_id, deleted) VALUES (2, '언더스코어 강력 추천드려요. 다만 최신 버전을 공부하는 것보다는 0.10.0 버전부터 보는게 더 좋더군요. 코드의 변천사도 알 수 있고, 최적화되지 않은 코드들이 기능은 그대로 두고 최적화되어 가는 걸 보면 재미가 있습니다 :)', CURRENT_TIMESTAMP(), 1, false);
-INSERT INTO answer (writer_id, contents, create_date, question_id, deleted) VALUES (3, '언더스코어 강력 추천드려요. 다만 최신 버전을 공부하는 것보다는 0.10.0 버전부터 보는게 더 좋더군요. 코드의 변천사도 알 수 있고, 최적화되지 않은 코드들이 기능은 그대로 두고 최적화되어 가는 걸 보면 재미가 있습니다 :)', CURRENT_TIMESTAMP(), 1, false);
+INSERT INTO answer (writer_id, contents, create_date, question_id, deleted) VALUES (2, '댓글2입니다루루루루루루루', CURRENT_TIMESTAMP(), 1, false);
+INSERT INTO answer (writer_id, contents, create_date, question_id, deleted) VALUES (3, '댓글3입니다루루루루루루루루', CURRENT_TIMESTAMP(), 1, false);
 
 
 

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -3,13 +3,11 @@ INSERT INTO user (id, user_id, password, name, email) values (2, 'sanjigi', 'tes
 INSERT INTO user (id, user_id, password, name, email) values (3, 'gram', '1234', '이그램', 'gram@slipp.net');
 
 INSERT INTO question (id, writer_id, title, contents, create_date, deleted) VALUES (1, 1, '국내에서 Ruby on Rails와 Play가 활성화되기 힘든 이유는 뭘까?', 'Ruby on Rails(이하 RoR)는 2006년 즈음에 정말 뜨겁게 달아올랐다가 금방 가라 앉았다. Play 프레임워크는 정말 한 순간 잠시 눈에 뜨이다가 사라져 버렸다. RoR과 Play 기반으로 개발을 해보면 정말 생산성이 높으며, 웹 프로그래밍이 재미있기까지 하다. Spring MVC + JPA(Hibernate) 기반으로 진행하면 설정할 부분도 많고, 기본으로 지원하지 않는 기능도 많아 RoR과 Play에서 기본적으로 지원하는 기능을 서비스하려면 추가적인 개발이 필요하다.', CURRENT_TIMESTAMP(), false);
+INSERT INTO question (id, writer_id, title, contents, create_date, deleted) VALUES (2, 2, 'runtime 에 reflect 발동 주체 객체가 뭔지 알 방법이 있을까요?', '설계를 희한하게 하는 바람에 꼬인 문제같긴 합니다만. 여쭙습니다. 상황은 mybatis select 실행될 시에 return object 의 getter 가 호출되면서인데요. getter 안에 다른 property 에 의존중인 코드가 삽입되어 있어서, 만약 다른 mybatis select 구문에 해당 property 가 없다면 exception 이 발생하게 됩니다.', CURRENT_TIMESTAMP(), false);
 
 INSERT INTO answer (writer_id, contents, create_date, question_id, deleted) VALUES (1, 'http://underscorejs.org/docs/underscore.html Underscore.js 강추합니다! 쓸일도 많고, 코드도 길지 않고, 자바스크립트의 언어나 기본 API를 보완하는 기능들이라 자바스크립트 이해에 도움이 됩니다. 무엇보다 라이브러리 자체가 아주 유용합니다.', CURRENT_TIMESTAMP(), 1, false);
-
 INSERT INTO answer (writer_id, contents, create_date, question_id, deleted) VALUES (2, '언더스코어 강력 추천드려요. 다만 최신 버전을 공부하는 것보다는 0.10.0 버전부터 보는게 더 좋더군요. 코드의 변천사도 알 수 있고, 최적화되지 않은 코드들이 기능은 그대로 두고 최적화되어 가는 걸 보면 재미가 있습니다 :)', CURRENT_TIMESTAMP(), 1, false);
-
 INSERT INTO answer (writer_id, contents, create_date, question_id, deleted) VALUES (3, '언더스코어 강력 추천드려요. 다만 최신 버전을 공부하는 것보다는 0.10.0 버전부터 보는게 더 좋더군요. 코드의 변천사도 알 수 있고, 최적화되지 않은 코드들이 기능은 그대로 두고 최적화되어 가는 걸 보면 재미가 있습니다 :)', CURRENT_TIMESTAMP(), 1, false);
 
-INSERT INTO question (id, writer_id, title, contents, create_date, deleted) VALUES (2, 2, 'runtime 에 reflect 발동 주체 객체가 뭔지 알 방법이 있을까요?', '설계를 희한하게 하는 바람에 꼬인 문제같긴 합니다만. 여쭙습니다. 상황은 mybatis select 실행될 시에 return object 의 getter 가 호출되면서인데요. getter 안에 다른 property 에 의존중인 코드가 삽입되어 있어서, 만약 다른 mybatis select 구문에 해당 property 가 없다면 exception 이 발생하게 됩니다.', CURRENT_TIMESTAMP(), false);
 
 

--- a/src/test/java/codesquad/domain/QuestionTest.java
+++ b/src/test/java/codesquad/domain/QuestionTest.java
@@ -34,5 +34,5 @@ public class QuestionTest {
 		question.update(updatedQuestion, user);
 		assertThat(question, is(updatedQuestion));
 	}
-
+	
 }

--- a/src/test/java/codesquad/domain/QuestionTest.java
+++ b/src/test/java/codesquad/domain/QuestionTest.java
@@ -8,6 +8,8 @@ import javax.naming.AuthenticationException;
 import org.junit.Before;
 import org.junit.Test;
 
+import codesquad.CannotDeleteException;
+
 public class QuestionTest {
 
 	private Question question;
@@ -16,7 +18,7 @@ public class QuestionTest {
 
 	@Before
 	public void setUp() {
-		user = new User(1, "그램", "비밀번호", "이름", "test@mail");
+		user = new User(1, "javajigi", "비밀번호", "이름", "test@mail");
 		otherUser = new User(2, "두램", "비밀번호", "이름", "test@mail");
 		question = new Question("제목", "내용");
 		question.writeBy(user);
@@ -34,5 +36,33 @@ public class QuestionTest {
 		question.update(updatedQuestion, user);
 		assertThat(question, is(updatedQuestion));
 	}
+
+	@Test
+	public void delete본인() throws AuthenticationException, CannotDeleteException{
+		question.delete(user);
+		assertThat(question.isDeleted(), is(true));
+	}
+	
+	@Test(expected=AuthenticationException.class)
+	public void delete다른사람() throws AuthenticationException, CannotDeleteException{
+		question.delete(otherUser);
+	}
+
+	@Test
+	public void delete_댓글존재_모두질문유저꺼() throws AuthenticationException, CannotDeleteException{
+		Answer answer = new Answer(1L, user, question, "내용내용");
+		question.addAnswer(answer);
+		question.delete(user);
+		assertThat(question.isDeleted(), is(true));
+		assertThat(answer.isDeleted(), is(true));
+	}
+	
+	@Test(expected=CannotDeleteException.class)
+	public void delete_댓글존재_다른유저꺼() throws AuthenticationException, CannotDeleteException{
+		Answer answer = new Answer(1L, otherUser, question, "내용내용");
+		question.addAnswer(answer);
+		question.delete(user);
+	}
+	
 	
 }

--- a/src/test/java/codesquad/web/ApiQuestionAcceptanceTest.java
+++ b/src/test/java/codesquad/web/ApiQuestionAcceptanceTest.java
@@ -10,6 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 
 import codesquad.domain.AnswerRepository;
+import codesquad.domain.ContentType;
+import codesquad.domain.DeleteHistory;
+import codesquad.domain.DeleteHistoryRepository;
 import codesquad.domain.QuestionRepository;
 import codesquad.dto.QuestionDto;
 import support.test.AcceptanceTest;
@@ -21,6 +24,9 @@ public class ApiQuestionAcceptanceTest extends AcceptanceTest {
 	
 	@Autowired
 	private AnswerRepository answerRepository;
+
+	@Autowired
+	private DeleteHistoryRepository deleteHistoryRepository;
 
 	private static final Long EXIST_QUESTION = 1L;
 
@@ -62,6 +68,7 @@ public class ApiQuestionAcceptanceTest extends AcceptanceTest {
 		assertThat(questionRepository.findById(2L).get().isDeleted(), is(false));
 		basicAuthTemplate(defaultAnotherUser()).delete("/api/questions/2");
 		assertThat(questionRepository.findById(2L).get().isDeleted(), is(true));
+		assertThat(deleteHistoryRepository.findById(1L).get() , is(new DeleteHistory(1L,ContentType.QUESTION, 2L, defaultAnotherUser())));
 	}
 	
 	@Test
@@ -71,6 +78,9 @@ public class ApiQuestionAcceptanceTest extends AcceptanceTest {
 		basicAuthTemplate().delete("/api/questions/3");
 		assertThat(questionRepository.findById(3L).get().isDeleted(), is(true));
 		assertThat(answerRepository.findById(4L).get().isDeleted(), is(true));
+		
+		assertThat(deleteHistoryRepository.findById(2L).get() , is(new DeleteHistory(2L, ContentType.ANSWER, 4L, defaultUser())));
+		assertThat(deleteHistoryRepository.findById(3L).get() , is(new DeleteHistory(3L, ContentType.QUESTION, 3L, defaultUser())));
 	}
 	
 	@Test

--- a/src/test/java/codesquad/web/ApiQuestionAcceptanceTest.java
+++ b/src/test/java/codesquad/web/ApiQuestionAcceptanceTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 
+import codesquad.domain.AnswerRepository;
 import codesquad.domain.QuestionRepository;
 import codesquad.dto.QuestionDto;
 import support.test.AcceptanceTest;
@@ -17,6 +18,9 @@ public class ApiQuestionAcceptanceTest extends AcceptanceTest {
 
 	@Autowired
 	private QuestionRepository questionRepository;
+	
+	@Autowired
+	private AnswerRepository answerRepository;
 
 	private static final Long EXIST_QUESTION = 1L;
 
@@ -54,11 +58,29 @@ public class ApiQuestionAcceptanceTest extends AcceptanceTest {
 	}
 
 	@Test
-	public void delete() {
-		createResource(basicAuthTemplate(), "/api/questions",  createQuestionDto(4L));
-		assertThat(questionRepository.findById(4L).get().isDeleted(), is(false));
-		basicAuthTemplate().delete("/api/questions/4");
-		assertThat(questionRepository.findById(4L).get().isDeleted(), is(true));
+	public void delete_댓글없음() {
+		assertThat(questionRepository.findById(2L).get().isDeleted(), is(false));
+		basicAuthTemplate(defaultAnotherUser()).delete("/api/questions/2");
+		assertThat(questionRepository.findById(2L).get().isDeleted(), is(true));
+	}
+	
+	@Test
+	public void delete_댓글존재_모든댓글로그인유저꺼() {
+		createResource(basicAuthTemplate(), String.format("/api/answers/%d", 3L), "내용은5자이상");
+		assertThat(questionRepository.findById(3L).get().isDeleted(), is(false));
+		basicAuthTemplate().delete("/api/questions/3");
+		assertThat(questionRepository.findById(3L).get().isDeleted(), is(true));
+		assertThat(answerRepository.findById(4L).get().isDeleted(), is(true));
+	}
+	
+	@Test
+	public void delete_댓글존재_다른유저의댓글있음() {
+		assertThat(questionRepository.findById(1L).get().isDeleted(), is(false));
+		basicAuthTemplate().delete("/api/questions/1");
+		assertThat(questionRepository.findById(1L).get().isDeleted(), is(false));
+		assertThat(answerRepository.findById(1L).get().isDeleted(), is(false));
+		assertThat(answerRepository.findById(2L).get().isDeleted(), is(false));
+		assertThat(answerRepository.findById(3L).get().isDeleted(), is(false));
 	}
 	
 	public QuestionDto createQuestionDto(Long id) {

--- a/src/test/java/support/test/AcceptanceTest.java
+++ b/src/test/java/support/test/AcceptanceTest.java
@@ -19,6 +19,7 @@ import codesquad.domain.UserRepository;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public abstract class AcceptanceTest {
     private static final String DEFAULT_LOGIN_USER = "javajigi";
+    private static final String DEFAULT_LOGIN_ANOTHER_USER = "sanjigi";
     private static final String DEFAULT_LOGIN_OTHER_USER = "gram";
 
     @Autowired
@@ -41,6 +42,10 @@ public abstract class AcceptanceTest {
     
     protected User defaultUser() {
         return findByUserId(DEFAULT_LOGIN_USER);
+    }
+    
+    protected User defaultAnotherUser() {
+    	return findByUserId(DEFAULT_LOGIN_ANOTHER_USER);
     }
 
     protected User defaultOtherUser() {


### PR DESCRIPTION
QnA 4단계(객체지향개발)파트를 구현해보았습니다.

>질문 삭제 기능을 구현한다. 질문 삭제 기능의 요구사항
- 질문 데이터를 완전히 삭제하는 것이 아니라 데이터의 상태를 삭제 상태(deleted - boolean type)로 변경
- 로그인 사용자와 질문한 사람이 같은 경우 삭제 가능.
- 답변이 없는 경우 삭제가 가능.
- 질문자와 답변 글의 모든 답변자 같은 경우 삭제가 가능.
- 질문을 삭제할 때 답변 또한 삭제해야 하며, 답변의 삭제 또한 삭제 상태(deleted)를 변경.
- 질문자와 답변자가 다른 경우 답변을 삭제불가.
- 질문과 답변 삭제 이력에 대한 정보를 DeleteHistory를 활용해 남긴다.