### PR TITLE
Step3

### DIFF
--- a/src/main/java/codesquad/service/QnaService.java
+++ b/src/main/java/codesquad/service/QnaService.java
@@ -69,11 +69,15 @@ public class QnaService {
         return questionRepository.findAll(pageable).getContent();
     }
 
+    @Transactional
     public Answer addAnswer(User loginUser, long questionId, String contents) {
         Answer addAnswer = new Answer(loginUser, contents);
-        Question question = findById(questionId).orElseThrow(IllegalArgumentException::new);
-        question.addAnswer(addAnswer);
-        return answerRepository.save(addAnswer);
+        findById(questionId).map(question -> {
+            question.addAnswer(addAnswer);
+            return question;
+        }).orElseThrow(IllegalArgumentException::new);
+
+        return addAnswer;
     }
 
     public Answer deleteAnswer(User loginUser, long id) {

--- a/src/main/java/codesquad/web/ApiAnswerController.java
+++ b/src/main/java/codesquad/web/ApiAnswerController.java
@@ -1,0 +1,34 @@
+package codesquad.web;
+
+import codesquad.domain.Answer;
+import codesquad.domain.User;
+import codesquad.security.LoginUser;
+import codesquad.service.QnaService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.annotation.Resource;
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/questions/{questionId}/answers")
+public class ApiAnswerController {
+    private static final Logger logger = LoggerFactory.getLogger(ApiAnswerController.class);
+
+    @Resource(name = "qnaService")
+    private QnaService qnaService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@PathVariable("questionId") long questionId, @LoginUser User loginUser, @RequestBody String contents) {
+        Answer answer = qnaService.addAnswer(loginUser, questionId, contents);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create("/api/questions/" + questionId + "/answers/" + answer.getId()));
+        return new ResponseEntity<Void>(headers, HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/codesquad/web/ApiQuestionController.java
+++ b/src/main/java/codesquad/web/ApiQuestionController.java
@@ -1,0 +1,52 @@
+package codesquad.web;
+
+import codesquad.CannotDeleteException;
+import codesquad.domain.Question;
+import codesquad.domain.User;
+import codesquad.security.LoginUser;
+import codesquad.service.QnaService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.annotation.Resource;
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/questions")
+public class ApiQuestionController {
+    @Resource(name = "qnaService")
+    private QnaService qnaService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@Valid @RequestBody Question question, @LoginUser User loginUser) {
+        Question savedQuestion = qnaService.create(loginUser, question);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create("/api/questions/" + savedQuestion.getId()));
+        return new ResponseEntity<Void>(headers, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public Question show(@PathVariable long id) {
+        return qnaService.findById(id).get();
+    }
+
+    @PutMapping("/{id}")
+    public Question update(@PathVariable long id, @LoginUser User loginUser, @Valid @RequestBody Question updatedQuestion) {
+        return qnaService.update(loginUser, id, updatedQuestion);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable long id, @LoginUser User loginUser) {
+        try {
+            qnaService.deleteQuestion(loginUser, id);
+            return new ResponseEntity<Void>(HttpStatus.OK);
+        } catch (CannotDeleteException e) {
+            return new ResponseEntity<Void>(HttpStatus.FORBIDDEN);
+        }
+    }
+
+}

--- a/src/main/java/codesquad/web/ApiUserController.java
+++ b/src/main/java/codesquad/web/ApiUserController.java
@@ -18,7 +18,7 @@ public class ApiUserController {
     @Resource(name = "userService")
     private UserService userService;
 
-    @PostMapping("")
+    @PostMapping()
     public ResponseEntity<Void> create(@Valid @RequestBody User user) {
         User savedUser = userService.add(user);
 

--- a/src/test/java/codesquad/domain/AnswerTest.java
+++ b/src/test/java/codesquad/domain/AnswerTest.java
@@ -1,0 +1,26 @@
+package codesquad.domain;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import support.test.BaseTest;
+
+import static org.junit.Assert.*;
+
+public class AnswerTest extends BaseTest {
+    private static final Logger logger = LoggerFactory.getLogger(AnswerTest.class);
+
+    public static User owner = new User(1, "sehun", "test", "sehun", "test@test.com");
+    public static User other = new User(2, "sechun", "test", "sechun", "test@test.com");
+
+    public static Question question = new Question("title", "contents");
+    public static Question updateQuestion = new Question("title2", "contents2");
+
+    @Test
+    public void toQuestion() {
+        Answer newAnswer = new Answer(owner, "contents");
+        question.addAnswer(newAnswer);
+        logger.debug("newAnswer question : {}", newAnswer.getQuestion());
+        softly.assertThat(newAnswer.getQuestion()).isEqualTo(question);
+    }
+}

--- a/src/test/java/codesquad/domain/QuestionTest.java
+++ b/src/test/java/codesquad/domain/QuestionTest.java
@@ -7,12 +7,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import support.test.BaseTest;
 
-import static org.junit.Assert.*;
-
 public class QuestionTest extends BaseTest {
     private static final Logger logger = LoggerFactory.getLogger(QuestionTest.class);
 
-    public static User onwer = new User(1, "sehun", "test", "sehun", "test@test.com");
+    public static User owner = new User(1, "sehun", "test", "sehun", "test@test.com");
     public static User other = new User(2, "sechun", "test", "sechun", "test@test.com");
 
     public static Question question = new Question("title", "contents");
@@ -20,13 +18,13 @@ public class QuestionTest extends BaseTest {
 
     @Before
     public void setUp() throws Exception {
-        question.writeBy(onwer);
+        question.writeBy(owner);
         question.setId(1);
     }
 
     @Test
     public void update_owner() {
-        question.update(updateQuestion, onwer);
+        question.update(updateQuestion, owner);
         softly.assertThat(question.getTitle()).isEqualTo("title2");
     }
 
@@ -42,4 +40,5 @@ public class QuestionTest extends BaseTest {
         question.delete();
         logger.debug("question : {}", question.isDeleted());
     }
+
 }

--- a/src/test/java/codesquad/service/QnaServiceTest.java
+++ b/src/test/java/codesquad/service/QnaServiceTest.java
@@ -14,7 +14,6 @@ import support.test.BaseTest;
 
 import java.util.Optional;
 
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -89,7 +88,6 @@ public class QnaServiceTest extends BaseTest {
         Answer newAnswer = new Answer(testUser, contents);
         newAnswer.toQuestion(original);
         when(questionRepository.findById(1L)).thenReturn(Optional.of(original));
-        when(answerRepository.save(newAnswer)).thenReturn(new Answer(1L, testUser, original, contents));
 
         Answer result = qnaService.addAnswer(testUser, 1L, "contents");
         softly.assertThat(result.getWriter()).isEqualTo(testUser);

--- a/src/test/java/codesquad/service/QnaServiceTest.java
+++ b/src/test/java/codesquad/service/QnaServiceTest.java
@@ -80,8 +80,18 @@ public class QnaServiceTest extends BaseTest {
     @Test
     public void delete_by_owner() throws CannotDeleteException {
         when(questionRepository.findById(Long.valueOf(1))).thenReturn(Optional.of(original));
-
         qnaService.deleteQuestion(testUser, 1);
+    }
 
+    @Test
+    public void add_answer() {
+        String contents = "contents";
+        Answer newAnswer = new Answer(testUser, contents);
+        newAnswer.toQuestion(original);
+        when(questionRepository.findById(1L)).thenReturn(Optional.of(original));
+        when(answerRepository.save(newAnswer)).thenReturn(new Answer(1L, testUser, original, contents));
+
+        Answer result = qnaService.addAnswer(testUser, 1L, "contents");
+        softly.assertThat(result.getWriter()).isEqualTo(testUser);
     }
 }

--- a/src/test/java/codesquad/web/ApiAnswerAcceptanceTest.java
+++ b/src/test/java/codesquad/web/ApiAnswerAcceptanceTest.java
@@ -1,0 +1,25 @@
+package codesquad.web;
+
+import codesquad.domain.Answer;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import support.test.AcceptanceTest;
+import support.test.RestJsonDataBuilder;
+
+public class ApiAnswerAcceptanceTest extends AcceptanceTest {
+    private static final Logger logger = LoggerFactory.getLogger(ApiAnswerAcceptanceTest.class);
+    private static RestJsonDataBuilder restJsonDataBuilder;
+
+    @Test
+    public void create() {
+        String contents = "answer contents";
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/questions/1/answers");
+        ResponseEntity<Void> responseEntity = restJsonDataBuilder.createEntity(basicAuthTemplate(), contents, Void.class);
+
+        softly.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        softly.assertThat(restJsonDataBuilder.getLocation()).isEqualTo("/api/questions/1/answers/3");
+    }
+}

--- a/src/test/java/codesquad/web/ApiAnswerAcceptanceTest.java
+++ b/src/test/java/codesquad/web/ApiAnswerAcceptanceTest.java
@@ -1,6 +1,5 @@
 package codesquad.web;
 
-import codesquad.domain.Answer;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/codesquad/web/ApiQuestionAcceptanceTest.java
+++ b/src/test/java/codesquad/web/ApiQuestionAcceptanceTest.java
@@ -1,0 +1,107 @@
+package codesquad.web;
+
+import codesquad.domain.Question;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import support.test.AcceptanceTest;
+import support.test.RestJsonDataBuilder;
+
+
+public class ApiQuestionAcceptanceTest extends AcceptanceTest {
+    private static final Logger logger = LoggerFactory.getLogger(ApiQuestionAcceptanceTest.class);
+    private static RestJsonDataBuilder restJsonDataBuilder;
+
+    @Test
+    public void create() {
+        Question question = new Question("title", "contents");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/questions");
+        restJsonDataBuilder.createEntity(basicAuthTemplate(defaultUser()), question, String.class);
+
+        Question dbQuestion = restJsonDataBuilder.getResource(template(), Question.class);
+        logger.debug("dbQuestion : {}", dbQuestion);
+        softly.assertThat(dbQuestion).isNotNull();
+    }
+
+    @Test
+    public void update() {
+        Question question = new Question("title", "contents");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/questions");
+        ResponseEntity<Void> response = restJsonDataBuilder.createEntity(basicAuthTemplate(defaultUser()), question, Void.class);
+        softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        Question updateQuestion = new Question("title2", "contents2");
+
+        ResponseEntity<Question> responseEntity = restJsonDataBuilder
+                .updateEntity(basicAuthTemplate(defaultUser()), updateQuestion, Question.class);
+
+        softly.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        softly.assertThat(updateQuestion.getTitle()).isEqualTo(responseEntity.getBody().getTitle());
+    }
+
+    @Test
+    public void update_no_login() {
+        Question question = new Question("title", "contents");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/questions");
+        ResponseEntity<Void> response = restJsonDataBuilder.createEntity(basicAuthTemplate(defaultUser()), question, Void.class);
+        softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        Question updateQuestion = new Question("title2", "contents2");
+
+        ResponseEntity<String> responseEntity = restJsonDataBuilder.updateEntity(template(), updateQuestion, String.class);
+        softly.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        logger.debug("error message : {}", responseEntity.getBody());
+    }
+
+    @Test
+    public void update_by_another_user() {
+        Question question = new Question("title", "contents");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/questions");
+        ResponseEntity<Void> response = restJsonDataBuilder.createEntity(basicAuthTemplate(defaultUser()), question, Void.class);
+        softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        Question updateQuestion = new Question("title2", "contents2");
+
+        ResponseEntity<Void> responseEntity =
+                restJsonDataBuilder.updateEntity(basicAuthTemplate(secondUser()), updateQuestion, Void.class);
+        softly.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    public void delete() {
+        Question question = new Question("title", "contents");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/questions");
+        ResponseEntity<Void> response = restJsonDataBuilder.createEntity(basicAuthTemplate(defaultUser()), question, Void.class);
+        softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        ResponseEntity<Void> responseEntity = restJsonDataBuilder.deleteEntity(basicAuthTemplate(), Void.class);
+        softly.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    public void delete_no_login() {
+        Question question = new Question("title", "contents");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/questions");
+        ResponseEntity<Void> response = restJsonDataBuilder.createEntity(basicAuthTemplate(defaultUser()), question, Void.class);
+        softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        ResponseEntity<Void> responseEntity = restJsonDataBuilder.deleteEntity(template(), Void.class);
+        softly.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    public void delete_other_user() {
+        Question question = new Question("title", "contents");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/questions");
+        ResponseEntity<Void> response = restJsonDataBuilder.createEntity(basicAuthTemplate(defaultUser()), question, Void.class);
+        softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        ResponseEntity<Void> responseEntity = restJsonDataBuilder.deleteEntity(basicAuthTemplate(secondUser()), Void.class);
+        softly.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+}
+
+

--- a/src/test/java/codesquad/web/ApiUserAcceptanceTest.java
+++ b/src/test/java/codesquad/web/ApiUserAcceptanceTest.java
@@ -12,20 +12,22 @@ import static codesquad.domain.UserTest.newUser;
 
 public class ApiUserAcceptanceTest extends AcceptanceTest {
     private static final Logger log = LoggerFactory.getLogger(ApiUserAcceptanceTest.class);
+    private static RestJsonDataBuilder restJsonDataBuilder;
 
     @Test
     public void create() throws Exception {
         User newUser = newUser("testuser1");
-        String location = createResource("/api/users", newUser);
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
+        restJsonDataBuilder.createEntity(template(), newUser, String.class);
 
-        User dbUser = getResource(location, User.class, newUser);
+        User dbUser = restJsonDataBuilder.getResource(basicAuthTemplate(newUser), User.class);
         softly.assertThat(dbUser).isNotNull();
     }
 
     @Test
     public void show_다른_사람() throws Exception {
         User newUser = newUser("testuser2");
-        RestJsonDataBuilder restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
 
         ResponseEntity<Void> response = restJsonDataBuilder.createEntity(template(), newUser, Void.class);
         softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
@@ -37,10 +39,10 @@ public class ApiUserAcceptanceTest extends AcceptanceTest {
     @Test
     public void update() throws Exception {
         User newUser = newUser("testuser3");
-        RestJsonDataBuilder restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
         ResponseEntity<Void> response = restJsonDataBuilder.createEntity(template(), newUser, Void.class);
         softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        User original = basicAuthTemplate(newUser).getForObject(restJsonDataBuilder.getLocation(), User.class);
+        User original = restJsonDataBuilder.getResource(basicAuthTemplate(newUser), User.class);
 
         User updateUser = new User
                 (original.getId(), original.getUserId(), original.getPassword(),
@@ -56,10 +58,10 @@ public class ApiUserAcceptanceTest extends AcceptanceTest {
     @Test
     public void update_no_login() throws Exception {
         User newUser = newUser("testuser4");
-        RestJsonDataBuilder restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
         ResponseEntity<Void> response = restJsonDataBuilder.createEntity(template(), newUser, Void.class);
         softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        User original = basicAuthTemplate(newUser).getForObject(restJsonDataBuilder.getLocation(), User.class);
+        User original = restJsonDataBuilder.getResource(basicAuthTemplate(newUser), User.class);
 
         User updateUser = new User
                 (original.getId(), original.getUserId(), original.getPassword(),
@@ -73,7 +75,7 @@ public class ApiUserAcceptanceTest extends AcceptanceTest {
     @Test
     public void update_다른_사람() throws Exception {
         User newUser = newUser("testuser5");
-        RestJsonDataBuilder restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
+        restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
         ResponseEntity<Void> response = restJsonDataBuilder.createEntity(template(), newUser, Void.class);
         softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 

--- a/src/test/java/codesquad/web/ApiUserAcceptanceTest.java
+++ b/src/test/java/codesquad/web/ApiUserAcceptanceTest.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.*;
 import support.test.AcceptanceTest;
+import support.test.RestJsonDataBuilder;
 
 import static codesquad.domain.UserTest.newUser;
 
@@ -15,39 +16,38 @@ public class ApiUserAcceptanceTest extends AcceptanceTest {
     @Test
     public void create() throws Exception {
         User newUser = newUser("testuser1");
-        ResponseEntity<Void> response = template().postForEntity("/api/users", newUser, Void.class);
-        softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        String location = response.getHeaders().getLocation().getPath();
+        String location = createResource("/api/users", newUser);
 
-        User dbUser = basicAuthTemplate(findByUserId(newUser.getUserId())).getForObject(location, User.class);
+        User dbUser = getResource(location, User.class, newUser);
         softly.assertThat(dbUser).isNotNull();
     }
 
     @Test
     public void show_다른_사람() throws Exception {
         User newUser = newUser("testuser2");
-        ResponseEntity<Void> response = template().postForEntity("/api/users", newUser, Void.class);
-        softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        String location = response.getHeaders().getLocation().getPath();
+        RestJsonDataBuilder restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
 
-        response = basicAuthTemplate(defaultUser()).getForEntity(location, Void.class);
+        ResponseEntity<Void> response = restJsonDataBuilder.createEntity(template(), newUser, Void.class);
+        softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        response = basicAuthTemplate(defaultUser()).getForEntity(restJsonDataBuilder.getLocation(), Void.class);
         softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
     @Test
     public void update() throws Exception {
         User newUser = newUser("testuser3");
-        ResponseEntity<Void> response = template().postForEntity("/api/users", newUser, Void.class);
-        String location = response.getHeaders().getLocation().getPath();
+        RestJsonDataBuilder restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
+        ResponseEntity<Void> response = restJsonDataBuilder.createEntity(template(), newUser, Void.class);
         softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        User original = basicAuthTemplate(newUser).getForObject(location, User.class);
+        User original = basicAuthTemplate(newUser).getForObject(restJsonDataBuilder.getLocation(), User.class);
 
         User updateUser = new User
                 (original.getId(), original.getUserId(), original.getPassword(),
                         "javajigi2", "javajigi2@slipp.net");
 
-        ResponseEntity<User> responseEntity =
-                basicAuthTemplate(newUser).exchange(location, HttpMethod.PUT, createHttpEntity(updateUser), User.class);
+        ResponseEntity<User> responseEntity = restJsonDataBuilder
+                .updateEntity(basicAuthTemplate(newUser), updateUser, User.class);
 
         softly.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         softly.assertThat(updateUser.equalsNameAndEmail(responseEntity.getBody())).isTrue();
@@ -56,18 +56,16 @@ public class ApiUserAcceptanceTest extends AcceptanceTest {
     @Test
     public void update_no_login() throws Exception {
         User newUser = newUser("testuser4");
-        ResponseEntity<Void> response = template().postForEntity("/api/users", newUser, Void.class);
-        String location = response.getHeaders().getLocation().getPath();
+        RestJsonDataBuilder restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
+        ResponseEntity<Void> response = restJsonDataBuilder.createEntity(template(), newUser, Void.class);
         softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        User original = basicAuthTemplate(newUser).getForObject(location, User.class);
+        User original = basicAuthTemplate(newUser).getForObject(restJsonDataBuilder.getLocation(), User.class);
 
         User updateUser = new User
                 (original.getId(), original.getUserId(), original.getPassword(),
                         "javajigi2", "javajigi2@slipp.net");
 
-        ResponseEntity<String> responseEntity =
-                template().exchange(location, HttpMethod.PUT, createHttpEntity(updateUser), String.class);
-
+        ResponseEntity<String> responseEntity = restJsonDataBuilder.updateEntity(template(), updateUser, String.class);
         softly.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         log.debug("error message : {}", responseEntity.getBody());
     }
@@ -75,20 +73,15 @@ public class ApiUserAcceptanceTest extends AcceptanceTest {
     @Test
     public void update_다른_사람() throws Exception {
         User newUser = newUser("testuser5");
-        ResponseEntity<Void> response = template().postForEntity("/api/users", newUser, Void.class);
+        RestJsonDataBuilder restJsonDataBuilder = new RestJsonDataBuilder("/api/users");
+        ResponseEntity<Void> response = restJsonDataBuilder.createEntity(template(), newUser, Void.class);
         softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        String location = response.getHeaders().getLocation().getPath();
 
         User updateUser = new User(newUser.getUserId(), "password", "name2", "javajigi@slipp.net2");
 
         ResponseEntity<Void> responseEntity =
-                basicAuthTemplate(defaultUser()).exchange(location, HttpMethod.PUT, createHttpEntity(updateUser), Void.class);
+                restJsonDataBuilder.updateEntity(basicAuthTemplate(defaultUser()), updateUser, Void.class);
         softly.assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
-    private HttpEntity createHttpEntity(Object body) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        return new HttpEntity(body, headers);
-    }
 }

--- a/src/test/java/codesquad/web/QuestionAcceptanceTest.java
+++ b/src/test/java/codesquad/web/QuestionAcceptanceTest.java
@@ -16,7 +16,7 @@ import support.test.HtmlFormDataBuilder;
 public class QuestionAcceptanceTest extends AcceptanceTest {
     private static final Logger logger = LoggerFactory.getLogger(QuestionAcceptanceTest.class);
 
-    private HtmlFormDataBuilder htmlFormDataBuilde;
+    private HtmlFormDataBuilder htmlFormDataBuilder;
 
     @Autowired
     private QuestionRepository questionRepository;
@@ -37,13 +37,13 @@ public class QuestionAcceptanceTest extends AcceptanceTest {
 
     @Test
     public void create() throws Exception {
-        htmlFormDataBuilde = HtmlFormDataBuilder.urlEncodedForm();
+        htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodedForm();
 
         User user = defaultUser();
-        htmlFormDataBuilde.addParameter("title", "test");
-        htmlFormDataBuilde.addParameter("contents", "contents");
+        htmlFormDataBuilder.addParameter("title", "test");
+        htmlFormDataBuilder.addParameter("contents", "contents");
 
-        ResponseEntity<String> response = basicAuthTemplate(user).postForEntity("/questions", htmlFormDataBuilde.build(), String.class);
+        ResponseEntity<String> response = basicAuthTemplate(user).postForEntity("/questions", htmlFormDataBuilder.build(), String.class);
 
         softly.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
         softly.assertThat(questionRepository.findByWriterId(user.getId())).isNotEmpty();
@@ -87,12 +87,12 @@ public class QuestionAcceptanceTest extends AcceptanceTest {
     }
 
     private ResponseEntity<String> update(TestRestTemplate template) throws UnAuthorizedException {
-        htmlFormDataBuilde = HtmlFormDataBuilder.urlEncodedForm().put();
+        htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodedForm().put();
 
-        htmlFormDataBuilde.addParameter("title", "title2");
-        htmlFormDataBuilde.addParameter("contents", "contents2");
+        htmlFormDataBuilder.addParameter("title", "title2");
+        htmlFormDataBuilder.addParameter("contents", "contents2");
 
-        return template.postForEntity(String.format("/questions/%d", 1), htmlFormDataBuilde.build(), String.class);
+        return template.postForEntity(String.format("/questions/%d", 1), htmlFormDataBuilder.build(), String.class);
     }
 
     @Test
@@ -117,9 +117,9 @@ public class QuestionAcceptanceTest extends AcceptanceTest {
     }
 
     private ResponseEntity<String> delete(TestRestTemplate template) {
-        htmlFormDataBuilde = HtmlFormDataBuilder.urlEncodedForm().delete();
+        htmlFormDataBuilder = HtmlFormDataBuilder.urlEncodedForm().delete();
 
-        return template.postForEntity(String.format("/questions/%d", 1), htmlFormDataBuilde.build(), String.class);
+        return template.postForEntity(String.format("/questions/%d", 1), htmlFormDataBuilder.build(), String.class);
     }
 
     @Test

--- a/src/test/java/support/test/AcceptanceTest.java
+++ b/src/test/java/support/test/AcceptanceTest.java
@@ -38,16 +38,6 @@ public abstract class AcceptanceTest extends BaseTest {
         return template.withBasicAuth(loginUser.getUserId(), loginUser.getPassword());
     }
 
-    protected String createResource(String path, Object bodyPayload) {
-        ResponseEntity<String> response = template().postForEntity(path, bodyPayload, String.class);
-        assertThat(response.getStatusCode(), is(HttpStatus.CREATED));
-        return response.getHeaders().getLocation().getPath();
-    }
-
-    protected <T> T getResource(String location, Class<T> responseType, User loginUser) {
-        return basicAuthTemplate(loginUser).getForObject(location, responseType);
-    }
-
     protected User defaultUser() {
         return findByUserId(DEFAULT_LOGIN_USER);
     }

--- a/src/test/java/support/test/AcceptanceTest.java
+++ b/src/test/java/support/test/AcceptanceTest.java
@@ -7,7 +7,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -31,6 +36,16 @@ public abstract class AcceptanceTest extends BaseTest {
 
     public TestRestTemplate basicAuthTemplate(User loginUser) {
         return template.withBasicAuth(loginUser.getUserId(), loginUser.getPassword());
+    }
+
+    protected String createResource(String path, Object bodyPayload) {
+        ResponseEntity<String> response = template().postForEntity(path, bodyPayload, String.class);
+        assertThat(response.getStatusCode(), is(HttpStatus.CREATED));
+        return response.getHeaders().getLocation().getPath();
+    }
+
+    protected <T> T getResource(String location, Class<T> responseType, User loginUser) {
+        return basicAuthTemplate(loginUser).getForObject(location, responseType);
     }
 
     protected User defaultUser() {

--- a/src/test/java/support/test/RestJsonDataBuilder.java
+++ b/src/test/java/support/test/RestJsonDataBuilder.java
@@ -1,5 +1,6 @@
 package support.test;
 
+import codesquad.domain.User;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
 
@@ -26,6 +27,10 @@ public class RestJsonDataBuilder {
 
     public <T> ResponseEntity<T> deleteEntity(TestRestTemplate template, Class<T> responseType) {
         return template.exchange(this.location, HttpMethod.DELETE, HttpEntity.EMPTY, responseType);
+    }
+
+    public <T> T getResource(TestRestTemplate template, Class<T> responseType) {
+        return template.getForObject(this.location, responseType);
     }
 
     private HttpEntity createHttpEntity(Object body) {

--- a/src/test/java/support/test/RestJsonDataBuilder.java
+++ b/src/test/java/support/test/RestJsonDataBuilder.java
@@ -1,0 +1,36 @@
+package support.test;
+
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+
+public class RestJsonDataBuilder {
+    private String location;
+
+    public RestJsonDataBuilder(String location) {
+        this.location = location;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public <T> ResponseEntity<T> createEntity(TestRestTemplate template, Object request, Class<T> responseType) {
+        ResponseEntity<T> responseEntity = template.postForEntity(this.location, request, responseType);
+        this.location = responseEntity.getHeaders().getLocation().getPath();
+        return responseEntity;
+    }
+
+    public <T> ResponseEntity<T> updateEntity(TestRestTemplate template, Object body, Class<T> responseType) {
+        return (ResponseEntity<T>) template.exchange(this.location, HttpMethod.PUT, createHttpEntity(body), responseType);
+    }
+
+    public <T> ResponseEntity<T> deleteEntity(TestRestTemplate template, Class<T> responseType) {
+        return template.exchange(this.location, HttpMethod.DELETE, HttpEntity.EMPTY, responseType);
+    }
+
+    private HttpEntity createHttpEntity(Object body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity(body, headers);
+    }
+}


### PR DESCRIPTION
### atdd step3입니다.
- `ApiQuestionController`, `ApiAnswerController` 요구사항 반영하여 만들었습니다.
-  `ResponseEntity"를 만들게 도와주는 `RestJsonDataBuilder`로 중복을 제거하였습니다.
- `Question`,`Answer`를 삭제하는 부분은 다음 step에 구현하도록 하겠습니다.

#### 질문
포비는 `Answer`를 만들 수 있는 생성자를 user와 contents를 받는 생성자와 (id, user, question, contents)를 만들 수 있는 생성자로 나누어 두셨는데. 두 번째 생성자를 만드신 의도는 테스트용으로 Answer를 만들기 위해 쓰시는 것이라 생각했습니다.

첫 번째 생성자로 `Answer`를 만들 경우 `Repository`에 save하기 전에 `Question`을 `Answer`에 주입해 주어야하고 setter를 따로 `toQuestion()`이란 메소드로 만들어 놓은 것을 찾았습니다. 

```java
    public void addAnswer(Answer answer) {
        answer.toQuestion(this);
        answers.add(answer);
    }
```
해당 메소드를 `Question` 도메인에서 `addAnswer()`라는 메소드 안에서 호출하고 있는데, 포비는 `Answer` 엔티티를 `addAnswer()`를 활용하여 `Question` 도메인에 저장하여 `QuestionRepository`에 save하게 하여 `Answer`엔티티를 저장하게 하려는 의도인지 궁금합니다.